### PR TITLE
Replace broken ISL library URL

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -96,7 +96,7 @@ download_sources()
     "https://ftp.gnu.org/gnu/gmp/gmp-$v_gmp.tar.xz"
     "https://ftp.gnu.org/gnu/mpfr/mpfr-$v_mpfr.tar.xz"
     "https://ftp.gnu.org/gnu/mpc/mpc-$v_mpc.tar.gz"
-    "http://isl.gforge.inria.fr/isl-$v_isl.tar.xz"
+    "https://libisl.sourceforge.io/isl-$v_isl.tar.xz"
   )
 
   for url in "${urls[@]}"; do


### PR DESCRIPTION
Hey Chris! Inria have apparently been in the process of shutting down their gforge project hosting service that ISL used ([link](https://giters.com/coq/opam-coq-archive/issues/1298?amp=1)), and seems to have actually pulled the trigger a few days ago, which broke this script.

Following discussion in the `isl-development` Google group ([link](https://groups.google.com/g/isl-development/c/JGaMo2VUu_8?pli=1)), it seems there's a Sourceforge mirror: https://libisl.sourceforge.io/

Replacing the domain in the URL should deal with the problem.